### PR TITLE
Add LinearCombination transform

### DIFF
--- a/src/Transforms.jl
+++ b/src/Transforms.jl
@@ -2,11 +2,12 @@ module Transforms
 
 using Tables
 
-export Transform, Power
+export LinearCombination, Transform, Power
 export transform, transform!
 
 include("utils.jl")
 include("transformers.jl")
+include("linear_combination.jl")
 include("power.jl")
 
 end

--- a/src/linear_combination.jl
+++ b/src/linear_combination.jl
@@ -1,7 +1,7 @@
 """
     LinearCombination(coefficients) <: Transform
 
-Calculate the linear combination using the column weights passed in.
+Calculate the linear combination using the vector coefficients passed in.
 """
 struct LinearCombination <: Transform
     coefficients::Vector{Real}

--- a/src/linear_combination.jl
+++ b/src/linear_combination.jl
@@ -18,28 +18,42 @@ end
 
 _sum_row(row, col_weights) = sum(map(*, row, col_weights))
 
-function apply(x::AbstractVector, LC::LinearCombination; kwargs...)
+"""
+    apply(x, LC::LinearCombination; cols=Colon())
+
+Applies the [`LinearCombination`](@ref) to each of the specified columns in `x`.
+If no `cols` are specified, then the [`LinearCombination`](@ref) is applied to all columns.
+"""
+function apply(x::AbstractVector, LC::LinearCombination; cols=Colon())
     # Treat each element as it's own column
     # Error if dimensions don't match
-    num_cols = length(x)
+    num_cols = cols isa Colon ? length(x) : length(cols)
     _check_dimensions_match(LC, num_cols)
 
-    return [_sum_row(x, LC.col_weights)]
+    return [_sum_row(x[cols], LC.col_weights)]
 end
 
-function apply(x::AbstractArray, LC::LinearCombination; kwargs...)
+function apply(x::AbstractArray, LC::LinearCombination; cols=Colon())
     # Error if dimensions don't match
-    num_cols = size(x, 2)
+    num_cols = cols isa Colon ? size(x, 2) : length(cols)
     _check_dimensions_match(LC, num_cols)
 
-    return [_sum_row(row, LC.col_weights) for row in eachrow(x)]
+    return [_sum_row(row[cols], LC.col_weights) for row in eachrow(x)]
 end
 
-function apply(x, LC::LinearCombination; kwargs...)
+function apply(x, LC::LinearCombination; cols=nothing)
     # Error if dimensions don't match
-    column_names = Tables.columnnames(x)
-    num_cols = length(column_names)
+    num_cols = cols === nothing ? length(Tables.columnnames(x)) : length(cols)
     _check_dimensions_match(LC, num_cols)
 
-    return [_sum_row(row, LC.col_weights) for row in Tables.rows(x)]
+    # Keep the generic form when not specifying column names
+    # because that is much more performant than selecting each col by name
+    if cols === nothing
+        return [_sum_row(row, LC.col_weights) for row in Tables.rows(x)]
+    else
+        return [
+            _sum_row([row[cname] for cname in cols], LC.col_weights)
+            for row in Tables.rows(x)
+        ]
+    end
 end

--- a/src/linear_combination.jl
+++ b/src/linear_combination.jl
@@ -1,0 +1,45 @@
+"""
+    LinearCombination <: Transform
+
+Calculate the linear combination using the column weights passed in.
+"""
+struct LinearCombination <: Transform
+    col_weights::Vector{Real}
+end
+
+function _check_dimensions_match(LC::LinearCombination, num_cols)
+    num_weights = length(LC.col_weights)
+    if num_cols != num_weights
+        throw(DimensionMismatch(
+            "Number of cols ($num_cols) doesn't match number of weights ($num_weights)"
+        ))
+    end
+end
+
+_sum_row(row, col_weights) = sum(map(*, row, col_weights))
+
+function apply(x::AbstractVector, LC::LinearCombination; kwargs...)
+    # Treat each element as it's own column
+    # Error if dimensions don't match
+    num_cols = length(x)
+    _check_dimensions_match(LC, num_cols)
+
+    return [_sum_row(x, LC.col_weights)]
+end
+
+function apply(x::AbstractArray, LC::LinearCombination; kwargs...)
+    # Error if dimensions don't match
+    num_cols = size(x, 2)
+    _check_dimensions_match(LC, num_cols)
+
+    return [_sum_row(row, LC.col_weights) for row in eachrow(x)]
+end
+
+function apply(x, LC::LinearCombination; kwargs...)
+    # Error if dimensions don't match
+    column_names = Tables.columnnames(x)
+    num_cols = length(column_names)
+    _check_dimensions_match(LC, num_cols)
+
+    return [_sum_row(row, LC.col_weights) for row in Tables.rows(x)]
+end

--- a/src/linear_combination.jl
+++ b/src/linear_combination.jl
@@ -38,7 +38,7 @@ end
     apply(x::AbstractMatrix, LC::LinearCombination; dims=1, inds=Colon())
 
 Applies the [`LinearCombination`](@ref) to each of the specified indices in `x` along the
-dimension specified, which defaults to applying it row-wise for each column of x."
+dimension specified, which defaults to applying it row-wise for each column of x.
 
 If no `inds` are specified, then the [`LinearCombination`](@ref) is applied to all columns.
 """

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -14,6 +14,15 @@
             x = [1, 2, 3]
             @test_throws DimensionMismatch Transforms.apply(x, lc)
         end
+
+        @testset "specified cols" begin
+            x = [1, 2, 3]
+            cols = [2, 3]
+            expected = [-1]
+
+            @test Transforms.apply(x, lc; cols=cols) == expected
+            @test lc(x; cols=cols) == expected
+        end
     end
 
     @testset "Matrix" begin
@@ -24,14 +33,23 @@
         @test lc(M) == expected
 
         # Does this just test dims is ignored?
-        @testset "dims = $d" for d in (Colon(), 1, 2)
-            @test Transforms.apply(M, lc; dims=d) == expected
-            @test lc(M; dims=d) == expected
-        end
+        # @testset "dims = $d" for d in (Colon(), 1, 2)
+        #     @test Transforms.apply(M, lc; dims=d) == expected
+        #     @test lc(M; dims=d) == expected
+        # end
 
         @testset "dimension mismatch" begin
-           M = [1 1 1; 2 2 2]
-           @test_throws DimensionMismatch Transforms.apply(M, lc)
+            M = [1 1 1; 2 2 2]
+            @test_throws DimensionMismatch Transforms.apply(M, lc)
+        end
+
+        @testset "specified cols" begin
+            M = [1 1 5; 2 2 4]
+            cols = [2, 3]
+            expected = [-4, -2]
+
+            @test Transforms.apply(M, lc; cols=cols) == expected
+            @test lc(M; cols=cols) == expected
         end
     end
 
@@ -49,20 +67,38 @@
             nt = (a = [1, 2, 3], b = [4, 5, 6], c = [1, 1, 1])
             @test_throws DimensionMismatch Transforms.apply(nt, lc)
         end
+
+        @testset "specified cols" begin
+            nt = (a = [1, 2, 3], b = [4, 5, 6], c = [1, 1, 1])
+            cols = [:a, :b]
+            expected = [-3, -3, -3]
+
+            @test Transforms.apply(nt, lc; cols=cols) == expected
+            @test lc(nt; cols=cols) == expected
+        end
     end
 
     @testset "AxisArray" begin
         A = AxisArray([1 2; 4 5], foo=["a", "b"], bar=["x", "y"])
         expected = [-1, -1]
 
-        @testset "dims = $d" for d in (Colon(), 1, 2)
-            transformed = Transforms.apply(A, lc; dims=d)
-            @test transformed == expected
-        end
+        # @testset "dims = $d" for d in (Colon(), 1, 2)
+        #     transformed = Transforms.apply(A, lc; dims=d)
+        #     @test transformed == expected
+        # end
 
         @testset "dimension mismatch" begin
             A = AxisArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
             @test_throws DimensionMismatch Transforms.apply(A, lc)
+        end
+
+        @testset "specified cols" begin
+            A = AxisArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
+            cols = [1, 2]
+            expected = [-1, -1]
+
+            @test Transforms.apply(A, lc; cols=cols) == expected
+            @test lc(A; cols=cols) == expected
         end
     end
 
@@ -70,14 +106,23 @@
         A = KeyedArray([1 2; 4 5], foo=["a", "b"], bar=["x", "y"])
         expected = [-1, -1]
 
-        @testset "dims = $d" for d in (Colon(), :foo, :bar)
-            transformed = Transforms.apply(A, lc; dims=d)
-            @test transformed == expected
-        end
+        # @testset "dims = $d" for d in (Colon(), :foo, :bar)
+        #     transformed = Transforms.apply(A, lc; dims=d)
+        #     @test transformed == expected
+        # end
 
         @testset "dimension mismatch" begin
             A = KeyedArray([1 2 3; 4 5 6], foo=["a", "b"], bar=["x", "y", "z"])
             @test_throws DimensionMismatch Transforms.apply(A, lc)
+        end
+
+        @testset "specified cols" begin
+            A = KeyedArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
+            cols = [1, 2]
+            expected = [-1, -1]
+
+            @test Transforms.apply(A, lc; cols=cols) == expected
+            @test lc(A; cols=cols) == expected
         end
     end
 
@@ -91,6 +136,15 @@
         @testset "dimension mismatch" begin
             df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6], :c => [1, 1, 1])
             @test_throws DimensionMismatch Transforms.apply(df, lc)
+        end
+
+        @testset "specified cols" begin
+            df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6], :c => [1, 1, 1])
+            cols = [:b, :c]
+            expected = [3, 4, 5]
+
+            @test Transforms.apply(df, lc; cols=cols) == expected
+            @test lc(df; cols=cols) == expected
         end
     end
 end

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -40,20 +40,26 @@
             @test lc(M) == expected
         end
 
-        # TODO: Colon() is not supported by eachslice(A, dims=:), do we care?
         @testset "dims" begin
+            @testset "dims = :" begin
+                d = Colon()
+                @test_throws ArgumentError Transforms.apply(M, lc; dims=d)
+            end
+
             @testset "dims = 1" begin
-                @test Transforms.apply(M, lc; dims=1) == expected
-                @test lc(M; dims=1) == expected
+                d = 1
+                @test Transforms.apply(M, lc; dims=d) == expected
+                @test lc(M; dims=d) == expected
             end
 
             @testset "dims = 2" begin
+                d = 2
                 # There are 3 rows so trying to apply along dim 2 without specifying inds
                 # won't work
-                @test_throws DimensionMismatch Transforms.apply(M, lc; dims=2)
+                @test_throws DimensionMismatch Transforms.apply(M, lc; dims=d)
 
-                @test Transforms.apply(M, lc; dims=2, inds=[2, 3]) == [-1, -3]
-                @test lc(M; dims=2, inds=[1, 3]) == [-2, -4]
+                @test Transforms.apply(M, lc; dims=d, inds=[2, 3]) == [-1, -3]
+                @test lc(M; dims=d, inds=[1, 3]) == [-2, -4]
             end
         end
 
@@ -82,14 +88,21 @@
         end
 
         @testset "dims" begin
+            @testset "dims = :" begin
+                d = Colon()
+                @test_throws ArgumentError Transforms.apply(A, lc; dims=d)
+            end
+
             @testset "dims = 1" begin
-                @test Transforms.apply(A, lc; dims=1) == expected
-                @test lc(A; dims=1) == expected
+                d = 1
+                @test Transforms.apply(A, lc; dims=d) == expected
+                @test lc(A; dims=d) == expected
             end
 
             @testset "dims = 2" begin
-                @test Transforms.apply(A, lc; dims=2) == [-3, -3]
-                @test lc(A; dims=2) == [-3, -3]
+                d = 2
+                @test Transforms.apply(A, lc; dims=d) == [-3, -3]
+                @test lc(A; dims=d) == [-3, -3]
             end
         end
 
@@ -118,14 +131,21 @@
         end
 
         @testset "dims" begin
+            @testset "dims = :" begin
+                d = Colon()
+                @test_throws ArgumentError Transforms.apply(A, lc; dims=d)
+            end
+
             @testset "dims = 1" begin
-                @test Transforms.apply(A, lc; dims=1) == expected
-                @test lc(A; dims=1) == expected
+                d = 1
+                @test Transforms.apply(A, lc; dims=d) == expected
+                @test lc(A; dims=d) == expected
             end
 
             @testset "dims = 2" begin
-                @test Transforms.apply(A, lc; dims=2) == [-3, -3]
-                @test lc(A; dims=2) == [-3, -3]
+                d = 2
+                @test Transforms.apply(A, lc; dims=d) == [-3, -3]
+                @test lc(A; dims=d) == [-3, -3]
             end
         end
 
@@ -164,11 +184,11 @@
 
         @testset "specified cols" begin
             nt = (a = [1, 2, 3], b = [4, 5, 6], c = [1, 1, 1])
-            inds = [:a, :b]
+            cols = [:a, :b]
             expected = [-3, -3, -3]
 
-            @test Transforms.apply(nt, lc; inds=inds) == expected
-            @test lc(nt; inds=inds) == expected
+            @test Transforms.apply(nt, lc; cols=cols) == expected
+            @test lc(nt; cols=cols) == expected
         end
     end
 
@@ -192,11 +212,11 @@
 
         @testset "specified cols" begin
             df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6], :c => [1, 1, 1])
-            inds = [:b, :c]
+            cols = [:b, :c]
             expected = [3, 4, 5]
 
-            @test Transforms.apply(df, lc; inds=inds) == expected
-            @test lc(df; inds=inds) == expected
+            @test Transforms.apply(df, lc; cols=cols) == expected
+            @test lc(df; cols=cols) == expected
         end
     end
 end

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -7,21 +7,27 @@
         x = [1, 2]
         expected = [-1]
 
-        @test Transforms.apply(x, lc) == expected
-        @test lc(x) == expected
+        @testset "all inds" begin
+            @test Transforms.apply(x, lc) == expected
+            @test lc(x) == expected
+        end
+
+        @testset "dims not supported" begin
+            @test_throws  MethodError Transforms.apply(x, lc; dims=1)
+        end
 
         @testset "dimension mismatch" begin
             x = [1, 2, 3]
             @test_throws DimensionMismatch Transforms.apply(x, lc)
         end
 
-        @testset "specified cols" begin
+        @testset "specified inds" begin
             x = [1, 2, 3]
-            cols = [2, 3]
+            inds = [2, 3]
             expected = [-1]
 
-            @test Transforms.apply(x, lc; cols=cols) == expected
-            @test lc(x; cols=cols) == expected
+            @test Transforms.apply(x, lc; inds=inds) == expected
+            @test lc(x; inds=inds) == expected
         end
     end
 
@@ -29,27 +35,112 @@
         M = [1 1; 2 2; 3 5]
         expected = [0, 0, -2]
 
-        @test Transforms.apply(M, lc) == expected
-        @test lc(M) == expected
+        @testset "all inds" begin
+            @test Transforms.apply(M, lc) == expected
+            @test lc(M) == expected
+        end
 
-        # Does this just test dims is ignored?
-        # @testset "dims = $d" for d in (Colon(), 1, 2)
-        #     @test Transforms.apply(M, lc; dims=d) == expected
-        #     @test lc(M; dims=d) == expected
-        # end
+        # TODO: Colon() is not supported by eachslice(A, dims=:), do we care?
+        @testset "dims" begin
+            @testset "dims = 1" begin
+                @test Transforms.apply(M, lc; dims=1) == expected
+                @test lc(M; dims=1) == expected
+            end
+
+            @testset "dims = 2" begin
+                # There are 3 rows so trying to apply along dim 2 without specifying inds
+                # won't work
+                @test_throws DimensionMismatch Transforms.apply(M, lc; dims=2)
+
+                @test Transforms.apply(M, lc; dims=2, inds=[2, 3]) == [-1, -3]
+                @test lc(M; dims=2, inds=[1, 3]) == [-2, -4]
+            end
+        end
 
         @testset "dimension mismatch" begin
             M = [1 1 1; 2 2 2]
             @test_throws DimensionMismatch Transforms.apply(M, lc)
         end
 
-        @testset "specified cols" begin
+        @testset "specified inds" begin
             M = [1 1 5; 2 2 4]
-            cols = [2, 3]
+            inds = [2, 3]
             expected = [-4, -2]
 
-            @test Transforms.apply(M, lc; cols=cols) == expected
-            @test lc(M; cols=cols) == expected
+            @test Transforms.apply(M, lc; inds=inds) == expected
+            @test lc(M; inds=inds) == expected
+        end
+    end
+
+    @testset "AxisArray" begin
+        A = AxisArray([1 2; 4 5], foo=["a", "b"], bar=["x", "y"])
+        expected = [-1, -1]
+
+        @testset "all inds" begin
+            @test Transforms.apply(A, lc) == expected
+            @test lc(A) == expected
+        end
+
+        @testset "dims" begin
+            @testset "dims = 1" begin
+                @test Transforms.apply(A, lc; dims=1) == expected
+                @test lc(A; dims=1) == expected
+            end
+
+            @testset "dims = 2" begin
+                @test Transforms.apply(A, lc; dims=2) == [-3, -3]
+                @test lc(A; dims=2) == [-3, -3]
+            end
+        end
+
+        @testset "dimension mismatch" begin
+            A = AxisArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
+            @test_throws DimensionMismatch Transforms.apply(A, lc)
+        end
+
+        @testset "specified inds" begin
+            A = AxisArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
+            inds = [1, 2]
+            expected = [-1, -1]
+
+            @test Transforms.apply(A, lc; inds=inds) == expected
+            @test lc(A; inds=inds) == expected
+        end
+    end
+
+    @testset "AxisKey" begin
+        A = KeyedArray([1 2; 4 5], foo=["a", "b"], bar=["x", "y"])
+        expected = [-1, -1]
+
+        @testset "all inds" begin
+            @test Transforms.apply(A, lc) == expected
+            @test lc(A) == expected
+        end
+
+        @testset "dims" begin
+            @testset "dims = 1" begin
+                @test Transforms.apply(A, lc; dims=1) == expected
+                @test lc(A; dims=1) == expected
+            end
+
+            @testset "dims = 2" begin
+                @test Transforms.apply(A, lc; dims=2) == [-3, -3]
+                @test lc(A; dims=2) == [-3, -3]
+            end
+        end
+
+        @testset "dimension mismatch" begin
+            A = KeyedArray([1 2 3; 4 5 6], foo=["a", "b"], bar=["x", "y", "z"])
+            @test_throws DimensionMismatch Transforms.apply(A, lc)
+        end
+
+        @testset "specified inds" begin
+            A = KeyedArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
+            inds = [1, 2]
+            expected = [-1, -1]
+
+            @test Transforms.apply(A, lc; inds=inds) == expected
+            @test lc(A; inds=inds) == expected
         end
     end
 
@@ -58,9 +149,12 @@
         expected = [-3, -3, -3]
 
         @testset "all cols" begin
-            transformed = Transforms.apply(nt, lc)
-            @test transformed == expected
+            @test Transforms.apply(nt, lc) == expected
             @test lc(nt) == expected
+        end
+
+        @testset "dims not supported" begin
+            @test_throws MethodError Transforms.apply(nt, lc; dims=1)
         end
 
         @testset "dimension mismatch" begin
@@ -70,59 +164,11 @@
 
         @testset "specified cols" begin
             nt = (a = [1, 2, 3], b = [4, 5, 6], c = [1, 1, 1])
-            cols = [:a, :b]
+            inds = [:a, :b]
             expected = [-3, -3, -3]
 
-            @test Transforms.apply(nt, lc; cols=cols) == expected
-            @test lc(nt; cols=cols) == expected
-        end
-    end
-
-    @testset "AxisArray" begin
-        A = AxisArray([1 2; 4 5], foo=["a", "b"], bar=["x", "y"])
-        expected = [-1, -1]
-
-        # @testset "dims = $d" for d in (Colon(), 1, 2)
-        #     transformed = Transforms.apply(A, lc; dims=d)
-        #     @test transformed == expected
-        # end
-
-        @testset "dimension mismatch" begin
-            A = AxisArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
-            @test_throws DimensionMismatch Transforms.apply(A, lc)
-        end
-
-        @testset "specified cols" begin
-            A = AxisArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
-            cols = [1, 2]
-            expected = [-1, -1]
-
-            @test Transforms.apply(A, lc; cols=cols) == expected
-            @test lc(A; cols=cols) == expected
-        end
-    end
-
-    @testset "AxisKey" begin
-        A = KeyedArray([1 2; 4 5], foo=["a", "b"], bar=["x", "y"])
-        expected = [-1, -1]
-
-        # @testset "dims = $d" for d in (Colon(), :foo, :bar)
-        #     transformed = Transforms.apply(A, lc; dims=d)
-        #     @test transformed == expected
-        # end
-
-        @testset "dimension mismatch" begin
-            A = KeyedArray([1 2 3; 4 5 6], foo=["a", "b"], bar=["x", "y", "z"])
-            @test_throws DimensionMismatch Transforms.apply(A, lc)
-        end
-
-        @testset "specified cols" begin
-            A = KeyedArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
-            cols = [1, 2]
-            expected = [-1, -1]
-
-            @test Transforms.apply(A, lc; cols=cols) == expected
-            @test lc(A; cols=cols) == expected
+            @test Transforms.apply(nt, lc; inds=inds) == expected
+            @test lc(nt; inds=inds) == expected
         end
     end
 
@@ -130,8 +176,14 @@
         df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6])
         expected = [-3, -3, -3]
 
-        transformed = Transforms.apply(df, lc)
-        @test transformed == expected
+        @testset "all cols" begin
+            @test Transforms.apply(df, lc) == expected
+            @test lc(df) == expected
+        end
+
+        @testset "dims not supported" begin
+            @test_throws MethodError Transforms.apply(df, lc; dims=1)
+        end
 
         @testset "dimension mismatch" begin
             df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6], :c => [1, 1, 1])
@@ -140,11 +192,11 @@
 
         @testset "specified cols" begin
             df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6], :c => [1, 1, 1])
-            cols = [:b, :c]
+            inds = [:b, :c]
             expected = [3, 4, 5]
 
-            @test Transforms.apply(df, lc; cols=cols) == expected
-            @test lc(df; cols=cols) == expected
+            @test Transforms.apply(df, lc; inds=inds) == expected
+            @test lc(df; inds=inds) == expected
         end
     end
 end

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -1,0 +1,96 @@
+@testset "linear combination" begin
+
+    lc = LinearCombination([1, -1])
+    @test lc isa Transform
+
+    @testset "Vector" begin
+        x = [1, 2]
+        expected = [-1]
+
+        @test Transforms.apply(x, lc) == expected
+        @test lc(x) == expected
+
+        @testset "dimension mismatch" begin
+            x = [1, 2, 3]
+            @test_throws DimensionMismatch Transforms.apply(x, lc)
+        end
+    end
+
+    @testset "Matrix" begin
+        M = [1 1; 2 2; 3 5]
+        expected = [0, 0, -2]
+
+        @test Transforms.apply(M, lc) == expected
+        @test lc(M) == expected
+
+        # Does this just test dims is ignored?
+        @testset "dims = $d" for d in (Colon(), 1, 2)
+            @test Transforms.apply(M, lc; dims=d) == expected
+            @test lc(M; dims=d) == expected
+        end
+
+        @testset "dimension mismatch" begin
+           M = [1 1 1; 2 2 2]
+           @test_throws DimensionMismatch Transforms.apply(M, lc)
+        end
+    end
+
+    @testset "NamedTuple" begin
+        nt = (a = [1, 2, 3], b = [4, 5, 6])
+        expected = [-3, -3, -3]
+
+        @testset "all cols" begin
+            transformed = Transforms.apply(nt, lc)
+            @test transformed == expected
+            @test lc(nt) == expected
+        end
+
+        @testset "dimension mismatch" begin
+            nt = (a = [1, 2, 3], b = [4, 5, 6], c = [1, 1, 1])
+            @test_throws DimensionMismatch Transforms.apply(nt, lc)
+        end
+    end
+
+    @testset "AxisArray" begin
+        A = AxisArray([1 2; 4 5], foo=["a", "b"], bar=["x", "y"])
+        expected = [-1, -1]
+
+        @testset "dims = $d" for d in (Colon(), 1, 2)
+            transformed = Transforms.apply(A, lc; dims=d)
+            @test transformed == expected
+        end
+
+        @testset "dimension mismatch" begin
+            A = AxisArray([1 2 3; 4 5 5], foo=["a", "b"], bar=["x", "y", "z"])
+            @test_throws DimensionMismatch Transforms.apply(A, lc)
+        end
+    end
+
+    @testset "AxisKey" begin
+        A = KeyedArray([1 2; 4 5], foo=["a", "b"], bar=["x", "y"])
+        expected = [-1, -1]
+
+        @testset "dims = $d" for d in (Colon(), :foo, :bar)
+            transformed = Transforms.apply(A, lc; dims=d)
+            @test transformed == expected
+        end
+
+        @testset "dimension mismatch" begin
+            A = KeyedArray([1 2 3; 4 5 6], foo=["a", "b"], bar=["x", "y", "z"])
+            @test_throws DimensionMismatch Transforms.apply(A, lc)
+        end
+    end
+
+    @testset "DataFrame" begin
+        df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6])
+        expected = [-3, -3, -3]
+
+        transformed = Transforms.apply(df, lc)
+        @test transformed == expected
+
+        @testset "dimension mismatch" begin
+            df = DataFrame(:a => [1, 2, 3], :b => [4, 5, 6], :c => [1, 1, 1])
+            @test_throws DimensionMismatch Transforms.apply(df, lc)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,5 +6,6 @@ using Transforms: _try_copy
 using Test
 
 @testset "Transforms.jl" begin
+    include("linear_combination.jl")
     include("power.jl")
 end


### PR DESCRIPTION
Closes #5 

Note that I couldn't get a linear combination using [Statistics.mean](https://juliastats.org/StatsBase.jl/stable/means/#Statistics.mean) to work. A lot of operations were returning NaNs. Also, that mean function expects a whole matrix of weights and not just the weights for each column. For these reasons, I opted not to define the CustomTransform instead of doing this explicitly.

From the issue description, I am unclear what the role of `dims` kwarg is or how it should work.

