### PR TITLE
Clean up apply! code

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Transforms"
 uuid = "8fd68953-04b8-4117-ac19-158bf6de9782"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/one_hot_encoding.jl
+++ b/src/one_hot_encoding.jl
@@ -32,7 +32,7 @@ function _apply(x, encoding::OneHotEncoding; kwargs...)
 
     results = zeros(Int, length(x), n_categories)
 
-    for (i, value) in enumerate(x)
+    @views for (i, value) in enumerate(x)
         col_pos = encoding.categories[value]
         results[i, col_pos] = 1
     end

--- a/src/periodic.jl
+++ b/src/periodic.jl
@@ -43,11 +43,6 @@ function _apply(x, P::Periodic{T}; kwargs...) where T <: Period
     map(xi -> _periodic(P.f, xi, P.period, P.phase_shift), x)
 end
 
-function _apply!(x::AbstractArray{T}, P::Periodic; kwargs...) where T <: Real
-    x[:] = _apply(x, P; kwargs...)
-    return x
-end
-
 """
     _periodic(f, instant, period, phase_shift=Day(0))
 

--- a/src/power.jl
+++ b/src/power.jl
@@ -10,8 +10,3 @@ end
 function _apply(x::AbstractArray{T}, P::Power; kwargs...) where T <: Real
     return x .^ P.exponent
 end
-
-function _apply!(x::AbstractArray{T}, P::Power; kwargs...) where T <: Real
-    x[:] = _apply(x, P; kwargs...)
-    return x
-end

--- a/src/scaling.jl
+++ b/src/scaling.jl
@@ -74,7 +74,7 @@ function compute_stats(table; cols=nothing)
     return (; μ_pairs...), (; σ_pairs...)
 end
 
-function _apply!(
+function _apply(
     A::AbstractArray, scaling::MeanStdScaling;
     name=nothing, inverse=false, eps=1e-3, kwargs...
 )
@@ -82,13 +82,12 @@ function _apply!(
     μ = scaling.mean[name]
     σ = scaling.std[name]
     if inverse
-        A[:] = μ .+ σ .* A
+        return μ .+ σ .* A
     else
         # Avoid division by 0
         # If std is 0 then data was uniform, so the scaled value would end up ≈ 0
         # Therefore the particular `eps` value should not matter much.
         σ_safe = σ == 0 ? eps : σ
-        A[:] = (A .- μ) ./ σ_safe
+        return (A .- μ) ./ σ_safe
     end
-    return A
 end

--- a/src/temporal.jl
+++ b/src/temporal.jl
@@ -5,5 +5,4 @@ Get the hour of day corresponding to the data.
 """
 struct HoD <: Transform end
 
-
 _apply(x, ::HoD; kwargs...) = hour.(x)

--- a/src/transformers.jl
+++ b/src/transformers.jl
@@ -40,10 +40,10 @@ function apply end
 """
     apply!(data::T, ::Transform; kwargs...) -> T
 
-Applies the [`Transform`](@ref) mutating the input `data`. New transforms should usually
-only extend `_apply!` which this method delegates to.
+Applies the [`Transform`](@ref) mutating the input `data`. This method delegates to
+[`apply`](@ref) under the hood so does not need to be defined separately.
 
-Where necessary, this should be extended for new data types `T`.
+If [`Transform`](@ref) does not support mutation, this method will error.
 """
 function apply! end
 
@@ -136,7 +136,3 @@ function apply!(table::T, t::Transform; cols=nothing, kwargs...)::T where T
 
     return table
 end
-
-
-# Fallback method for when _apply is not directly defined
-_apply(x, t::Transform; kwargs...) = _apply!(_try_copy(x), t; kwargs...)

--- a/src/transformers.jl
+++ b/src/transformers.jl
@@ -52,7 +52,11 @@ function apply! end
     apply(A::AbstractArray, ::Transform; dims=:, inds=:, kwargs...)
 
 Applies the [`Transform`](@ref) to the elements of `A`.
+
 Provide the `dims` keyword to apply the [`Transform`](@ref) along a certain dimension.
+For example, given a `Matrix`, `dims=1` applies to each column, while `dims=2` applies
+to each row.
+
 Provide the `inds` keyword to apply the [`Transform`](@ref) to certain indices along the
 `dims` specified.
 
@@ -83,12 +87,9 @@ end
     apply!(A::AbstractArray, ::Transform; dims=:, kwargs...)
 
 Applies the [`Transform`](@ref) to each element of `A`, mutating the data.
-Optionally specify the `dims` to apply the [`Transform`](@ref) along certain dimensions.
-For example in a `Matrix`, `dims=1` applies to each column, while `dims=2` applies
-to each row.
 """
-function apply!(A::AbstractArray, t::Transform; dims=:, kwargs...)
-    A[:] = apply(A, t; dims=dims, kwargs...)
+function apply!(A::AbstractArray, t::Transform; kwargs...)
+    A[:] = apply(A, t; kwargs...)
     return A
 end
 

--- a/src/transformers.jl
+++ b/src/transformers.jl
@@ -72,12 +72,12 @@ function apply(A::AbstractArray, t::Transform; dims=:, inds=:, kwargs...)
         if inds === Colon()
             return _apply(A, t; kwargs...)
         else
-            return _apply(A[:][inds], t; kwargs...)
+            return @views _apply(A[:][inds], t; kwargs...)
         end
     end
 
     slice_index = 0
-    return mapslices(A, dims=dims) do x
+    return @views mapslices(A, dims=dims) do x
         slice_index += 1
         _apply(x[inds], t; name=Symbol(slice_index), kwargs...)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,14 +11,3 @@ function _try_copy(data)
         deepcopy(data)
     end
 end
-
-function invert_dims(A::AbstractArray, dims)
-    ndims(A) == 1 && return dims
-    # TODO: support named dims https://github.com/invenia/Transforms.jl/issues/20
-    inverted_dims = setdiff(1:ndims(A), dims)
-    if length(inverted_dims) == 1
-        inverted_dims = inverted_dims[1]
-    end
-
-    return inverted_dims
-end


### PR DESCRIPTION
Closes #18 

There is an unfortunate conflict in how the `dims` kwarg is implemented in `eachslice` vs `mapslices` #18 

`mapslices` is more intuitive to our researchers but it cannot be used to mutate data directly because it doesn't take a `view` of the underlying data (there is no such thing as a `mapview` https://github.com/JuliaLang/julia/issues/29146)

This is important for having a mutating `apply!` method, which is now only possible with `eachslices` + some workarounds.

This PR attempts to simplify this interface by just delegating to `apply` inside `apply!` and avoiding the complications involved in using `eachslice` in the first place. (The only place it is used in now is `LinearCombination`).

But since `apply!` delegates to `apply` which delegates to `_apply`, there is also no longer any need for the `_apply!` method.
So now users only need to implement one method (`_apply`) and `Transforms` takes care of the rest.

With this change I think the code is much simpler to follow and more "honest" in what it is using under-the-hood (`mapslices`).
However, I haven't taken steps to reduce allocations and it's probably 2x more expensive on that front but we can probably make those improvements as well.