### PR TITLE
Allow single column name for `cols`

### DIFF
--- a/src/linear_combination.jl
+++ b/src/linear_combination.jl
@@ -64,9 +64,7 @@ Applies the [`LinearCombination`](@ref) to each of the specified cols in `x`.
 If no `cols` are specified, then the [`LinearCombination`](@ref) is applied to all columns.
 """
 function apply(x, LC::LinearCombination; cols=nothing)
-    if cols isa Union{Symbol, AbstractString}  # want same behaviour for single column
-        cols = [cols]
-    end
+    cols = _to_vec(cols)  # handle single column name
 
     # Error if dimensions don't match
     num_cols = cols === nothing ? length(Tables.columnnames(x)) : length(cols)

--- a/src/linear_combination.jl
+++ b/src/linear_combination.jl
@@ -64,6 +64,10 @@ Applies the [`LinearCombination`](@ref) to each of the specified cols in `x`.
 If no `cols` are specified, then the [`LinearCombination`](@ref) is applied to all columns.
 """
 function apply(x, LC::LinearCombination; cols=nothing)
+    if cols isa Union{Symbol, AbstractString}  # want same behaviour for single column
+        cols = [cols]
+    end
+
     # Error if dimensions don't match
     num_cols = cols === nothing ? length(Tables.columnnames(x)) : length(cols)
     _check_dimensions_match(LC, num_cols)

--- a/src/transformers.jl
+++ b/src/transformers.jl
@@ -110,10 +110,14 @@ function apply(table, t::Transform; cols=nothing, kwargs...)
 
     cnames = cols === nothing ? propertynames(columntable) : cols
 
-    return [
-        _apply(getproperty(columntable, cname), t; name=cname, kwargs...)
-        for cname in cnames
-    ]
+    if cnames isa Union{Symbol, AbstractString}  # want unwrapped single column
+        return _apply(getproperty(columntable, cnames), t; name=cnames, kwargs...)
+    else
+        return [
+            _apply(getproperty(columntable, cname), t; name=cname, kwargs...)
+            for cname in cnames
+        ]
+    end
 end
 
 """
@@ -125,6 +129,10 @@ If no `cols` are specified, then the [`Transform`](@ref) is applied to all colum
 function apply!(table::T, t::Transform; cols=nothing, kwargs...)::T where T
     # TODO: We could probably handle iterators of tables here
     Tables.istable(table) || throw(MethodError(apply!, (table, t)))
+
+    if cols isa Union{Symbol, AbstractString}  # want same behaviour for single column
+        cols = [cols]
+    end
 
     # Extract a columns iterator that we should be able to use to mutate the data.
     # NOTE: Mutation is not guaranteed for all table types, but it avoid copying the data

--- a/src/transformers.jl
+++ b/src/transformers.jl
@@ -110,13 +110,13 @@ function apply(table, t::Transform; cols=nothing, kwargs...)
 
     cnames = cols === nothing ? propertynames(columntable) : cols
 
-    if cnames isa Union{Symbol, AbstractString}  # want unwrapped single column
-        return _apply(getproperty(columntable, cnames), t; name=cnames, kwargs...)
-    else
+    if cnames isa Union{Tuple, AbstractArray}
         return [
             _apply(getproperty(columntable, cname), t; name=cname, kwargs...)
             for cname in cnames
         ]
+    else  # return unwrapped single column
+        return _apply(getproperty(columntable, cnames), t; name=cnames, kwargs...)
     end
 end
 
@@ -130,9 +130,7 @@ function apply!(table::T, t::Transform; cols=nothing, kwargs...)::T where T
     # TODO: We could probably handle iterators of tables here
     Tables.istable(table) || throw(MethodError(apply!, (table, t)))
 
-    if cols isa Union{Symbol, AbstractString}  # want same behaviour for single column
-        cols = [cols]
-    end
+    cols = _to_vec(cols)
 
     # Extract a columns iterator that we should be able to use to mutate the data.
     # NOTE: Mutation is not guaranteed for all table types, but it avoid copying the data

--- a/src/transformers.jl
+++ b/src/transformers.jl
@@ -132,7 +132,7 @@ function apply!(table::T, t::Transform; cols=nothing, kwargs...)::T where T
     # TODO: We could probably handle iterators of tables here
     Tables.istable(table) || throw(MethodError(apply!, (table, t)))
 
-    cols = _to_vec(cols)
+    cols = _to_vec(cols)  # handle single column name
 
     # Extract a columns iterator that we should be able to use to mutate the data.
     # NOTE: Mutation is not guaranteed for all table types, but it avoid copying the data

--- a/src/transformers.jl
+++ b/src/transformers.jl
@@ -99,7 +99,9 @@ end
 Applies the [`Transform`](@ref) to each of the specified columns in the `table`.
 If no `cols` are specified, then the [`Transform`](@ref) is applied to all columns.
 
-Returns an array containing each transformed column, in the same order as `cols`.
+# Return
+* If `cols` is a single value (not in a list): the transformed column vector.
+* Otherwise: an array containing each transformed column, in the same order as `cols`.
 """
 function apply(table, t::Transform; cols=nothing, kwargs...)
     Tables.istable(table) || throw(MethodError(apply, (table, t)))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,3 +11,8 @@ function _try_copy(data)
         deepcopy(data)
     end
 end
+
+_to_vec(x::AbstractArray) = x
+_to_vec(x::Tuple) = x
+_to_vec(x::Nothing) = x
+_to_vec(x) = [x]

--- a/test/linear_combination.jl
+++ b/test/linear_combination.jl
@@ -190,6 +190,14 @@
             @test Transforms.apply(nt, lc; cols=cols) == expected
             @test lc(nt; cols=cols) == expected
         end
+
+        @testset "single col" begin
+            lc_single = LinearCombination([-1])
+
+            @test Transforms.apply(nt, lc_single; cols=:a) == [-1, -2, -3]
+            @test Transforms.apply(nt, lc_single; cols=[:a]) == [-1, -2, -3]
+            @test lc_single(nt; cols=:a) == [-1, -2, -3]
+        end
     end
 
     @testset "DataFrame" begin
@@ -217,6 +225,14 @@
 
             @test Transforms.apply(df, lc; cols=cols) == expected
             @test lc(df; cols=cols) == expected
+        end
+
+        @testset "single col" begin
+            lc_single = LinearCombination([-1])
+
+            @test Transforms.apply(df, lc_single; cols=:a) == [-1, -2, -3]
+            @test Transforms.apply(df, lc_single; cols=[:a]) == [-1, -2, -3]
+            @test lc_single(df; cols=:a) == [-1, -2, -3]
         end
     end
 end

--- a/test/one_hot_encoding.jl
+++ b/test/one_hot_encoding.jl
@@ -110,6 +110,7 @@
 
         @testset "cols = $c" for c in (:a, :b)
             @test Transforms.apply(nt, ohe; cols=[c]) == [expected_nt[c]]
+            @test Transforms.apply(nt, ohe; cols=c) == expected_nt[c]
             @test ohe(nt; cols=[c]) == [expected_nt[c]]
         end
     end
@@ -121,6 +122,7 @@
         @test Transforms.apply(df, ohe) == expected
 
         @test Transforms.apply(df, ohe; cols=[:a]) == [[1 0 0 0 0; 0 1 0 0 0]]
+        @test Transforms.apply(df, ohe; cols=:a) == [1 0 0 0 0; 0 1 0 0 0]
         @test Transforms.apply(df, ohe; cols=[:b]) ==[[0 0 0 1 0; 0 0 0 0 1]]
     end
 end

--- a/test/scaling.jl
+++ b/test/scaling.jl
@@ -138,6 +138,7 @@
 
             @testset "cols = $c" for c in (:a, :b)
                 @test Transforms.apply(nt, scaling; cols=[c]) ≈ [nt_expected[c]]
+                @test Transforms.apply(nt, scaling; cols=c) ≈ nt_expected[c]
             end
 
             @testset "Inverse" begin
@@ -160,6 +161,7 @@
 
             @testset "cols = $c" for c in (:a, :b)
                 @test Transforms.apply(df, scaling; cols=[c]) ≈ [df_expected[!, c]]
+                @test Transforms.apply(df, scaling; cols=c) ≈ df_expected[!, c]
             end
 
             @testset "Inverse" begin
@@ -467,6 +469,7 @@
                 nt_expected_ = merge(nt, nt_mutated)
 
                 @test Transforms.apply(nt, scaling; cols=[c]) ≈ [collect(nt_expected_[c])] atol=1e-14
+                @test Transforms.apply(nt, scaling; cols=c) ≈ collect(nt_expected_[c]) atol=1e-14
                 @test scaling(nt; cols=[c]) ≈ [collect(nt_expected_[c])] atol=1e-14
 
                 _nt = deepcopy(nt)
@@ -517,8 +520,8 @@
             @testset "cols = $c" for c in (:a, :b)
                 scaling = MeanStdScaling(df; cols=[c])
 
-                transformed = Transforms.apply(df, scaling; cols=[c])
-                @test transformed ≈ [df_expected[!, c]] atol=1e-5
+                @test Transforms.apply(df, scaling; cols=[c]) ≈ [df_expected[!, c]] atol=1e-5
+                @test Transforms.apply(df, scaling; cols=c) ≈ df_expected[!, c] atol=1e-5
 
                 _df = deepcopy(df)
                 _df_expected = deepcopy(df)

--- a/test/temporal.jl
+++ b/test/temporal.jl
@@ -146,6 +146,7 @@
 
         @testset "cols = $c" for c in (:a, :b)
             @test Transforms.apply(nt, hod; cols=[c]) == [expected_nt[c]]
+            @test Transforms.apply(nt, hod; cols=c) == expected_nt[c]
             @test hod(nt; cols=[c]) == [expected_nt[c]]
         end
     end
@@ -168,6 +169,7 @@
         end
 
         @test Transforms.apply(df, hod; cols=[:a]) == [expected_df.a]
+        @test Transforms.apply(df, hod; cols=:a) == expected_df.a
         @test Transforms.apply(df, hod; cols=[:b]) ==[expected_df.b]
     end
 end


### PR DESCRIPTION
Closes #26 

This is the behaviour using a single column name (i.e. not a list):
- `apply` returns the single transformed column, "unwrapped"
  - Except for `LinearCombination`, because it always produces one column anyway
- `apply!` allows it, but gives the same result